### PR TITLE
Fix closing tag in projects page

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -25,7 +25,7 @@ featured_image: /images/social.jpg
 
 			<div class="listing-post__content">
 				<p>{{ project.excerpt }}</p>
-				<p><a href="{{ project.url }}" class="button">View Project</a>
+                                <p><a href="{{ project.url }}" class="button">View Project</a></p>
 			</div>
 
 		</article>


### PR DESCRIPTION
## Summary
- fix a missing `</p>` tag in `projects/index.html`

## Testing
- `python3 - <<'EOF'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.stack=[]; self.errors=[]
    def handle_starttag(self, tag, attrs):
        if tag not in ('br','img','meta','input','link','hr'):
            self.stack.append(tag)
    def handle_endtag(self, tag):
        if not self.stack or self.stack[-1]!=tag:
            self.errors.append(f"mismatch {tag}")
        else:
            self.stack.pop()
with open('projects/index.html') as f:
    data=f.read()
p=MyParser(); p.feed(data)
print(p.errors,p.stack)
EOF